### PR TITLE
1.1 added bypass cache and follow location

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,24 @@ file in mysite/_config
         - 401
         - 403
         - 501
+
+## Follow 301 redirects ##
+
+You may want to follow a redirected URL a example of this would be redirecting from http to https
+can give you a false poitive as the http code of 301 will be returned which will be classed
+as a working link.
+
+To allow redirects to be followed setup the following config in your config.yml
+
+    # Follow 301 redirects
+    CurlLinkChecker:
+      FollowLocation: 1
+
+## Bypass cache ##
+
+By default the task will attempt to cache any results the cache can be bypassed with the
+following config in config.yml.
+
+    # Bypass SS_Cache
+    CurlLinkChecker:
+      BypassCache: 1

--- a/code/tasks/CurlLinkChecker.php
+++ b/code/tasks/CurlLinkChecker.php
@@ -6,6 +6,24 @@
 class CurlLinkChecker implements LinkChecker {
 
 	/**
+	 * If we want to follow redirects a 301 http code for example
+	 * Set via YAML file
+	 *
+	 * @config
+	 * @var boolean
+	 */
+	private static $FollowLocation = false;
+
+	/**
+	 * If we want to bypass the cache
+	 * Set via YAML file
+	 *
+	 * @config
+	 * @var boolean
+	 */
+	private static $BypassCache = false;
+
+	/**
 	 * Return cache
 	 *
 	 * @return Zend_Cache_Frontend


### PR DESCRIPTION
The module can give false positives for broken links when the site in question has enabled redirects from http to https because the first code that will be returned will be 301 but a following 404 code can then be returned.

This pull request adds the option of specifying if you want to follow the location with a yml setting.
I have also added a yml setting to bypass the cache.

Both of these new features need to be specified in the config to make it backwards compatible.