### PR TITLE
FIX Use correct CacheInterface API methods and remove doubled up logic

### DIFF
--- a/src/Tasks/CurlLinkChecker.php
+++ b/src/Tasks/CurlLinkChecker.php
@@ -54,20 +54,13 @@ class CurlLinkChecker implements LinkChecker
             return null;
         }
 
+        $cacheKey = md5($href);
         if (!$this->config()->get('bypass_cache')) {
             // Check if we have a cached result
-            $cacheKey = md5($href);
-            $result = $this->getCache()->load($cacheKey);
+            $result = $this->getCache()->get($cacheKey, false);
             if ($result !== false) {
                 return $result;
             }
-        }
-
-        // Check if we have a cached result
-        $cacheKey = md5($href);
-        $result = $this->getCache()->get($cacheKey, false);
-        if ($result !== false) {
-            return $result;
         }
 
         // No cached result so just request
@@ -84,7 +77,7 @@ class CurlLinkChecker implements LinkChecker
 
         if (!$this->config()->get('bypass_cache')) {
             // Cache result
-            $this->getCache()->save($httpCode, $cacheKey);
+            $this->getCache()->set($cacheKey, $httpCode);
         }
         return $httpCode;
     }


### PR DESCRIPTION
I'd guess this was a dodgy merge up from SS3. The correct changes were originally made in 0374d66b3207bd412c3e1ac69558ec657db1c1f4 but lost again.

Fixes #46 