### PR TITLE
FIX Replace Convert JSON methods with json_* methods, deprecated from SilverStripe 4.4

### DIFF
--- a/src/Controllers/CMSExternalLinksController.php
+++ b/src/Controllers/CMSExternalLinksController.php
@@ -36,7 +36,7 @@ class CMSExternalLinksController extends Controller
         // Format status
         $track = BrokenExternalPageTrackStatus::get_latest();
         if ($track) {
-            return Convert::array2json([
+            return json_encode([
                 'TrackID' => $track->ID,
                 'Status' => $track->Status,
                 'Completed' => $track->getCompletedPages(),


### PR DESCRIPTION
Issue: https://github.com/silverstripe/silverstripe-framework/issues/8424