### PR TITLE
FIX External links report generate button is now disabled while it is loading

### DIFF
--- a/javascript/BrokenExternalLinksReport.js
+++ b/javascript/BrokenExternalLinksReport.js
@@ -53,6 +53,7 @@
 
         // set button to "submitting" state
         $button.addClass('btn--loading loading');
+        $button.attr('disabled', true);
 
         if ($button.is('button')) {
           $button.append($(
@@ -75,6 +76,7 @@
         var $button = this.getButton();
 
         $button.removeClass('btn--loading loading');
+        $button.attr('disabled', false);
         $button.find('.btn__loading-icon').remove();
         $button.css('width', 'auto');
       },


### PR DESCRIPTION
Otherwise you can still click on the button.