### PR TITLE
FIX Add missing namespace import - unknown HTTP status codes are now handled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 matrix:
   include:
     - php: '5.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,17 @@
 language: php
 
-env:
-  global:
-    - COMPOSER_ROOT_VERSION=2.0.x-dev
-
 matrix:
   include:
-    - php: 5.6
-      env: DB=MYSQL RECIPE_VERSION=1.0.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
-    - php: 7.0
-      env: DB=MYSQL RECIPE_VERSION=1.1.x-dev PHPUNIT_TEST=1
-    - php: 7.1
-      env: DB=PGSQL RECIPE_VERSION=1.2.x-dev PHPUNIT_COVERAGE_TEST=1
-    - php: 7.2
-      env: DB=MYSQL RECIPE_VERSION=1.x-dev PHPUNIT_TEST=1
+    - php: '5.6'
+      env: DB=MYSQL RECIPE_VERSION=4.3.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
+    - php: '7.0'
+      env: DB=MYSQL RECIPE_VERSION=4.3.x-dev PHPUNIT_TEST=1
+    - php: '7.1'
+      env: DB=PGSQL RECIPE_VERSION=4.4.x-dev PHPUNIT_COVERAGE_TEST=1
+    - php: '7.2'
+      env: DB=MYSQL RECIPE_VERSION=4.5.x-dev PHPUNIT_TEST=1
+    - php: '7.3'
+      env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1
 
 before_script:
   # Init PHP
@@ -23,7 +21,7 @@ before_script:
   # Install composer dependencies
   - composer validate
   - composer require --no-update silverstripe/recipe-cms $RECIPE_VERSION
-  - if [[ $DB == PGSQL ]]; then composer require --no-update silverstripe/postgresql 2.1.x-dev; fi
+  - if [[ $DB == PGSQL ]]; then composer require --no-update silverstripe/postgresql 2.x-dev; fi
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:

--- a/src/Model/BrokenExternalLink.php
+++ b/src/Model/BrokenExternalLink.php
@@ -2,9 +2,9 @@
 
 namespace SilverStripe\ExternalLinks\Model;
 
+use InvalidArgumentException;
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\HTTPResponse;
-use SilverStripe\ExternalLinks\Model\BrokenExternalPageTrack;
-use SilverStripe\ExternalLinks\Model\BrokenExternalPageTrackStatus;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\Security;
@@ -12,6 +12,8 @@ use SilverStripe\Security\Security;
 /**
  * Represents a single link checked for a single run that is broken
  *
+ * @property string Link
+ * @property int HTTPCode
  * @method BrokenExternalPageTrack Track()
  * @method BrokenExternalPageTrackStatus Status()
  */

--- a/tests/Model/BrokenExternalLinkTest.php
+++ b/tests/Model/BrokenExternalLinkTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SilverStripe\ExternalLinks\Tests\Model;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ExternalLinks\Model\BrokenExternalLink;
+
+class BrokenExternalLinkTest extends SapphireTest
+{
+    /**
+     * @param int $httpCode
+     * @param string $expected
+     * @dataProvider httpCodeProvider
+     */
+    public function testGetHTTPCodeDescription($httpCode, $expected)
+    {
+        $link = new BrokenExternalLink();
+        $link->HTTPCode = $httpCode;
+        $this->assertSame($expected, $link->getHTTPCodeDescription());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function httpCodeProvider()
+    {
+        return [
+            [200, '200 (OK)'],
+            [302, '302 (Found)'],
+            [404, '404 (Not Found)'],
+            [500, '500 (Internal Server Error)'],
+            [789, '789 (Unknown Response Code)'],
+        ];
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-externallinks/issues/61